### PR TITLE
Fix bug in build_windows.ps1

### DIFF
--- a/scripts/build_windows.ps1
+++ b/scripts/build_windows.ps1
@@ -76,7 +76,7 @@ if (-not (Test-Path $exePath)) {
   $sevenZipCandidates = @(
     (Join-Path $env:ProgramFiles '7-Zip\7z.exe'),
     (Join-Path ${env:ProgramFiles(x86)} '7-Zip\7z.exe'),
-    (Get-Command 7z -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source -ErrorAction SilentlyContinue)
+    (Get-Command 7z -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source -ErrorAction SilentlyContinue))
   $sevenZip = $sevenZipCandidates | Where-Object { $_ -and (Test-Path $_) } | Select-Object -First 1
   if ($sevenZip) {
     Write-Host "Creating portable zip with 7-Zip: $zipOut"


### PR DESCRIPTION
Add missing paren at the end of line 79 to close the definition of $sevenZipCandidates

I tried to run the script but it couldn't find my Python installation. That may be unique to my machine because I have multiple versions installed. Unfortunately I can't really spend more time on it right now, especially not being familiar with PowerShell scripting. So you could see if this bugfix is enough for it to work for others, or wait until one of us has more time to test it.